### PR TITLE
Updates examples to make aws profile a var

### DIFF
--- a/examples/packer-aws/amazon-linux-2.pkr.hcl
+++ b/examples/packer-aws/amazon-linux-2.pkr.hcl
@@ -12,6 +12,12 @@ packer {
   }
 }
 
+variable "aws_profile" {
+  type = string
+  description = "AWS profile to use. Typically found in ~/.aws/credentials"
+  default = "default"
+}
+
 variable "aws_region" {
   default = "us-east-1"
   type    = string
@@ -26,7 +32,7 @@ variable "image_prefix" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "amazon2" {
-  profile       = "default"
+  profile       = var.aws_profile
   ami_name      = "${var.image_prefix}-${local.timestamp}"
   instance_type = "t2.micro"
   region        = var.aws_region

--- a/examples/packer-aws/ubuntu-2004.pkr.hcl
+++ b/examples/packer-aws/ubuntu-2004.pkr.hcl
@@ -11,6 +11,12 @@ packer {
   }
 }
 
+variable "aws_profile" {
+  type = string
+  description = "AWS profile to use. Typically found in ~/.aws/credentials"
+  default = "default"
+}
+
 variable "aws_region" {
   default = "us-east-1"
   type    = string
@@ -25,7 +31,7 @@ variable "image_prefix" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "ubuntu2004" {
-  profile       = "default"
+  profile       = var.aws_profile
   ami_name      = "${var.image_prefix}-${local.timestamp}"
   instance_type = "t2.micro"
   region        = var.aws_region

--- a/examples/packer-aws/windows-2019.pkr.hcl
+++ b/examples/packer-aws/windows-2019.pkr.hcl
@@ -11,6 +11,12 @@ packer {
   }
 }
 
+variable "aws_profile" {
+  type = string
+  description = "AWS profile to use. Typically found in ~/.aws/credentials"
+  default = "default"
+}
+
 variable "aws_region" {
   default = "us-east-1"
   type    = string
@@ -25,7 +31,7 @@ variable "image_prefix" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "windows2019" {
-  profile       = "default"
+  profile       = var.aws_profile
   ami_name      = "${var.image_prefix}-${local.timestamp}"
   communicator  = "winrm"
   instance_type = "t2.micro"


### PR DESCRIPTION
A quick change to make `AWS_PROFILE` a variable.

Signed-off-by: Scott Ford <scott@scottford.io>