### PR TITLE
⭐Add a prod build make job.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X version.Version={{.Version}} -X version.Build={{.ShortCommit}} -X version.Date={{.Date}}
+      - -s -w -X go.mondoo.com/packer-plugin-mondoo/version.Version={{.Version}} -X go.mondoo.com/packer-plugin-mondoo/version.Build={{.ShortCommit}} -X go.mondoo.com/packer-plugin-mondoo/version.Date={{.Date}}
 archives:
   - id: releases
     name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,7 @@
 .PHONY: prep/plugins install build test
 
-ifndef LATEST_VERSION_TAG
-LATEST_VERSION_TAG=$(shell git describe --abbrev=0 --tags)
-endif
-
-ifndef TAG
-TAG=$(shell git log --pretty=format:'%h' -n 1)
-endif
-
-
 PROVISIONER_BINARY_NAME=packer-plugin-mondoo
 PLUGINS_DIR=~/.packer.d/plugins
-LDFLAGSDIST= -ldflags="-s -w -X go.mondoo.com/packer-plugin-mondoo/version.Version=${LATEST_VERSION_TAG} -X go.mondoo.com/packer-plugin-mondoo/version.Build=${TAG}"
 
 prep/plugins:
 	mkdir -p ${PLUGINS_DIR}
@@ -22,11 +12,8 @@ build/generate:
 build/snapshot:
 	API_VERSION=x5.0 goreleaser release --snapshot --skip-publish --rm-dist
 
-build/prod:
-	CGO_ENABLED=0 installsuffix=cgo go build ${LDFLAGSDIST} -o ./dist/${PROVISIONER_BINARY_NAME}
-
 build/dev:
-	CGO_ENABLED=0 installsuffix=cgo go build -ldflags="-X version.Version=development" -o ./dist/${PROVISIONER_BINARY_NAME}
+	CGO_ENABLED=0 installsuffix=cgo go build -ldflags="-X 'version.Version=development'" -o ./dist/${PROVISIONER_BINARY_NAME}
 
 install: prep/plugins build/dev
 	rm ${PLUGINS_DIR}/${PROVISIONER_BINARY_NAME} || true

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
 .PHONY: prep/plugins install build test
 
+ifndef LATEST_VERSION_TAG
+LATEST_VERSION_TAG=$(shell git describe --abbrev=0 --tags)
+endif
+
+ifndef TAG
+TAG=$(shell git log --pretty=format:'%h' -n 1)
+endif
+
+
 PROVISIONER_BINARY_NAME=packer-plugin-mondoo
 PLUGINS_DIR=~/.packer.d/plugins
+LDFLAGSDIST= -ldflags="-s -w -X go.mondoo.com/packer-plugin-mondoo/version.Version=${LATEST_VERSION_TAG} -X go.mondoo.com/packer-plugin-mondoo/version.Build=${TAG}"
 
 prep/plugins:
 	mkdir -p ${PLUGINS_DIR}
@@ -12,8 +22,11 @@ build/generate:
 build/snapshot:
 	API_VERSION=x5.0 goreleaser release --snapshot --skip-publish --rm-dist
 
+build/prod:
+	CGO_ENABLED=0 installsuffix=cgo go build ${LDFLAGSDIST} -o ./dist/${PROVISIONER_BINARY_NAME}
+
 build/dev:
-	CGO_ENABLED=0 installsuffix=cgo go build -ldflags="-X 'version.Version=development'" -o ./dist/${PROVISIONER_BINARY_NAME}
+	CGO_ENABLED=0 installsuffix=cgo go build -ldflags="-X version.Version=development" -o ./dist/${PROVISIONER_BINARY_NAME}
 
 install: prep/plugins build/dev
 	rm ${PLUGINS_DIR}/${PROVISIONER_BINARY_NAME} || true

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -157,7 +157,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 }
 
 func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.Communicator, generatedData map[string]interface{}) error {
-	ui.Say("Running mondoo (Version: " + version.Version + ", Build: " + version.Build + ")")
+	ui.Say("Running Mondoo packer provisioner (Version: " + version.Version + ", Build: " + version.Build + ")")
 
 	err := mapstructure.Decode(generatedData, &p.buildInfo)
 	if err != nil {


### PR DESCRIPTION
I noticed during testing that the mondoo version and build are empty:
`==> amazon-ebs: Running mondoo (Version: , Build: )`

I added a `build/prod` make job that correctly assigns the values after which this gets fixed.

`==> amazon-ebs: Running Mondoo packer provisioner (Version: v0.2.1, Build: af68414)`

I am not sure on the release process and what needs to be changed there, could use some help if this PR gets approved