### PR TITLE
Bump mondoo plugin version in amazon-linux-2 example.

### DIFF
--- a/examples/packer-aws/amazon-linux-2.pkr.hcl
+++ b/examples/packer-aws/amazon-linux-2.pkr.hcl
@@ -6,7 +6,7 @@ packer {
       source  = "github.com/hashicorp/amazon"
     }
     mondoo = {
-      version = ">= 0.3.0"
+      version = ">= 0.4.0"
       source  = "github.com/mondoohq/mondoo"
     }
   }


### PR DESCRIPTION
Hasn't been committed in the last PR, so a quick fix here