### PR TITLE
Removes AWS_PROFILE env var from example templates

### DIFF
--- a/examples/packer-aws/amazon-linux-2.json
+++ b/examples/packer-aws/amazon-linux-2.json
@@ -1,6 +1,5 @@
 {
   "variables": {
-    "profile": "{{env `AWS_PROFILE`}}",
     "aws_region": "{{env `AWS_REGION`}}",
     "prefix": "{{env `PACKER_BUILD_PREFIX`}}",
     "timestamp": "{{isotime `20060102150405`}}",

--- a/examples/packer-aws/amazon-linux-2.pkr.hcl
+++ b/examples/packer-aws/amazon-linux-2.pkr.hcl
@@ -12,12 +12,6 @@ packer {
   }
 }
 
-variable "aws_profile" {
-  type = string
-  description = "AWS profile to use. Typically found in ~/.aws/credentials"
-  default = "default"
-}
-
 variable "aws_region" {
   default = "us-east-1"
   type    = string
@@ -38,7 +32,6 @@ variable "mondoo_config_path" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "amazon2" {
-  profile       = var.aws_profile
   ami_name      = "${var.image_prefix}-${local.timestamp}"
   instance_type = "t2.micro"
   region        = var.aws_region

--- a/examples/packer-aws/ubuntu-18.04.json
+++ b/examples/packer-aws/ubuntu-18.04.json
@@ -1,6 +1,5 @@
 {
   "variables": {
-    "profile": "{{env `AWS_PROFILE`}}",
     "aws_region": "{{env `AWS_REGION`}}",
     "prefix": "{{env `PACKER_BUILD_PREFIX`}}",
     "timestamp": "{{isotime `20060102150405`}}",

--- a/examples/packer-aws/ubuntu-20.04.json
+++ b/examples/packer-aws/ubuntu-20.04.json
@@ -1,6 +1,5 @@
 {
   "variables": {
-    "profile": "{{env `AWS_PROFILE`}}",
     "aws_region": "{{env `AWS_REGION`}}",
     "prefix": "{{env `PACKER_BUILD_PREFIX`}}",
     "timestamp": "{{isotime `20060102150405`}}",

--- a/examples/packer-aws/ubuntu-2004.pkr.hcl
+++ b/examples/packer-aws/ubuntu-2004.pkr.hcl
@@ -11,12 +11,6 @@ packer {
   }
 }
 
-variable "aws_profile" {
-  type = string
-  description = "AWS profile to use. Typically found in ~/.aws/credentials"
-  default = "default"
-}
-
 variable "aws_region" {
   default = "us-east-1"
   type    = string
@@ -37,7 +31,6 @@ variable "mondoo_config_path" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "ubuntu2004" {
-  profile       = var.aws_profile
   ami_name      = "${var.image_prefix}-${local.timestamp}"
   instance_type = "t2.micro"
   region        = var.aws_region

--- a/examples/packer-aws/ubuntu-2204.pkr.hcl
+++ b/examples/packer-aws/ubuntu-2204.pkr.hcl
@@ -11,12 +11,6 @@ packer {
   }
 }
 
-variable "aws_profile" {
-  type = string
-  description = "AWS profile to use. Typically found in ~/.aws/credentials"
-  default = "default"
-}
-
 variable "aws_region" {
   default = "us-east-1"
   type    = string
@@ -37,7 +31,6 @@ variable "mondoo_config_path" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "ubuntu2204" {
-  profile       = var.aws_profile
   ami_name      = "${var.image_prefix}-${local.timestamp}"
   instance_type = "t2.micro"
   region        = var.aws_region

--- a/examples/packer-aws/windows-2019.pkr.hcl
+++ b/examples/packer-aws/windows-2019.pkr.hcl
@@ -11,12 +11,6 @@ packer {
   }
 }
 
-variable "aws_profile" {
-  type = string
-  description = "AWS profile to use. Typically found in ~/.aws/credentials"
-  default = "default"
-}
-
 variable "aws_region" {
   default = "us-east-1"
   type    = string
@@ -37,7 +31,6 @@ variable "mondoo_config_path" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "windows2019" {
-  profile       = var.aws_profile
   ami_name      = "${var.image_prefix}-${local.timestamp}"
   communicator  = "winrm"
   instance_type = "t2.micro"


### PR DESCRIPTION
This PR removes the `AWS_PROFILE` environment variable from the AWS example templates. 

Closes https://github.com/mondoohq/packer-plugin-mondoo/issues/14


Signed-off-by: Scott Ford <scott@scottford.io>