### PR TITLE
Update provisioner docs

### DIFF
--- a/docs/provisioners/index.mdx
+++ b/docs/provisioners/index.mdx
@@ -1,15 +1,21 @@
 ---
-description: The Mondoo packer provisioner scans machine-image builds for vulnerabilities and misconfigurations by executing security policies-as-code.
+description: |
+    The Mondoo packer provisioner scans machine-image builds for vulnerabilities
+    and misconfigurations by executing security policies-as-code.
 page_title: Mondoo - Provisioner
-nav_title: Mondoo
+sidebar_title: Overview
 ---
 
 
 # Packer Plugin Mondoo
-
-`Mondoo` scans [Packer](https://www.packer.io) builds for vulnerabilities and misconfigurations by executing security policies-as-code enabled in [Mondoo Platform](https://console.mondoo.com). Mondoo Platform comes stocked with an ever-increasing collection of certified security policies which can be easily customize to meet your needs. 
-
 Mondoo supports scanning of Linux, Windows, and macOS, as well as Docker containers.
+
+- [mondoo](provisioners/mondoo) scans [Packer](https://www.packer.io)
+     builds for vulnerabilities and misconfigurations by executing security
+     policies-as-code enabled in [Mondoo Platform](https://console.mondoo.com).
+     Mondoo Platform comes stocked with an ever-increasing collection of
+     certified security policies which can be easily customize to meet your
+     needs.
 
 ## Get Started with Mondoo
 
@@ -19,9 +25,9 @@ If you are new to Mondoo you can get started by [signing up for a free account](
 
 Check out the [Building secure AMIs with Mondoo and Packer](https://mondoo.com/docs/tutorials/aws/build-secure-amis-packer/) tutorial on the Mondoo documentation site.
 
-# Installation
+## Plugin Installation
 
-## Using the packer init command
+### Using the packer init command
 Starting from version 1.7, Packer supports a new `packer init` command allowing automatic installation of Packer plugins. Read the [Packer documentation](https://www.packer.io/docs/commands/init) for more information.
 
 To install this plugin, copy and paste this code into your Packer configuration . Then, run `packer init`.
@@ -37,7 +43,7 @@ packer {
 }
 ```
 
-#### Manual installation
+### Manual installation
 
 You can find pre-built binary releases of the plugin [here](https://github.com/mondoohq/packer-plugin-mondoo/releases).
 
@@ -48,44 +54,6 @@ Once you have downloaded the latest archive corresponding to your target OS, unc
 
 If you prefer to build the plugin from sources, clone the GitHub repository locally and run the command `go build` from the root directory. Upon successful compilation, a `packer-plugin-mondoo` plugin binary file can be found in the root directory. To install the compiled plugin, please follow the official Packer documentation on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
 
-## Configuration Reference
-
-### Optional:
-@include '/provisioner/Config-not-required.mdx'
-
-#### SudoConfig
-@include '/provisioner/SudoConfig-not-required.mdx'
-
-### Basic Example
-
-```hcl
-  provisioner "mondoo" {
-    on_failure      = "continue"
-    mondoo_config_path = "/etc/mondoo-config.json"
-    score_threshold = 85
-    asset_name      = "example-secure-base-image"
-    sudo {
-      active = true
-    }
-
-    annotations = {
-      Source_AMI    = "{{ .SourceAMI }}"
-      Creation_Date = "{{ .SourceAMICreationDate }}"
-    }
-  }
-}
-```
-
 ## Sample Packer Templates
 
-You can find example Packer templates in the [examples](/examples/) directory in this repository.
-
-## Contributing
-
-* If you think you've found a bug in the code or you have a question regarding
-  the usage of this software, please reach out to us by opening an issue in
-  this GitHub repository.
-* Contributions to this project are welcome: if you want to add a feature or a
-  fix a bug, please do so by opening a Pull Request in this GitHub repository.
-  In case of feature contribution, we kindly ask you to open an issue to
-  discuss it beforehand.
+You can find example Packer templates in the [examples](https://github.com/mondoohq/packer-plugin-mondoo/tree/main/examples) directory in this repository.

--- a/docs/provisioners/mondoo.mdx
+++ b/docs/provisioners/mondoo.mdx
@@ -1,0 +1,47 @@
+---
+description: |
+    The Mondoo packer provisioner scans machine-image builds for vulnerabilities
+    and misconfigurations by executing security policies-as-code.
+page_title: Mondoo - Provisioner
+sidebar_title: Mondoo
+---
+
+# Mondoo Provisioner
+
+Type: `monodoo`
+
+The `mondoo` provisioner scans [Packer](https://www.packer.io)
+builds for vulnerabilities and misconfigurations by executing security
+policies-as-code enabled in [Mondoo Platform](https://console.mondoo.com).
+Mondoo Platform comes stocked with an ever-increasing collection of
+certified security policies which can be easily customize to meet your needs.
+
+Mondoo supports scanning of Linux, Windows, and macOS, as well as Docker containers.
+
+### Basic Example
+
+```hcl
+  provisioner "mondoo" {
+    on_failure      = "continue"
+    mondoo_config_path = "/etc/mondoo-config.json"
+    score_threshold = 85
+    asset_name      = "example-secure-base-image"
+    sudo {
+      active = true
+    }
+
+    annotations = {
+      Source_AMI    = "{{ .SourceAMI }}"
+      Creation_Date = "{{ .SourceAMICreationDate }}"
+    }
+  }
+}
+```
+
+## Configuration Reference
+
+### Optional:
+@include '/provisioner/Config-not-required.mdx'
+
+#### SudoConfig
+@include '/provisioner/SudoConfig-not-required.mdx'


### PR DESCRIPTION
The Packer plugin ingestion pipeline for remote docs requires the plugin
documentation be in a specific format/directory to ensure the correct documentation is being ingested.

This change move the documentation into a component type directory under the top-level docs directory, and splits the single documentation file into two separate files:
a plugin overview file (docs/provisioners/index.mdx),  and a provisioner specific file (docs/provisioner/mondoo.mdx).
